### PR TITLE
X11とWaylandでCapsLock状態の判定をわける

### DIFF
--- a/engine/engine.py
+++ b/engine/engine.py
@@ -1344,14 +1344,7 @@ class EngineHiragana(EngineModeless):
 
     def _keymap_state_changed_cb(self, keymap):
         if self._controller.is_onoff_by_caps():
-            lock = keymap.get_caps_lock_state()
-            if self._caps_lock_state != lock:
-                LOGGER.debug(f'_keymap_state_changed_cb: {keymap.get_caps_lock_state()}')
-                self._caps_lock_state = lock
-                if lock:
-                    self.enable_ime()
-                else:
-                    self.disable_ime()
+            self.set_mode_by_caps_lock(keymap.get_caps_lock_state())
         return True
 
     #
@@ -1370,6 +1363,16 @@ class EngineHiragana(EngineModeless):
             self.set_mode('あ', override)
             return True
         return False
+
+    def set_mode_by_caps_lock(self, lock: bool) -> None:
+        if self._caps_lock_state == lock:
+            return
+        LOGGER.debug(f'set_mode_by_caps_lock({lock})')
+        self._caps_lock_state = lock
+        if lock:
+            self.set_mode('あ')
+        else:
+            self.set_mode('A')
 
     def get_mode(self):
         return self._mode
@@ -1502,8 +1505,9 @@ class EngineHiragana(EngineModeless):
     def do_enable(self) -> None:
         super().do_enable()
         self._caps_lock_state = None
-        self._keymap_state_changed_cb(self._keymap)
-        self._keymap_handler = self._keymap.connect('state-changed', self._keymap_state_changed_cb)
+        if self._controller.is_onoff_by_caps() and not self.is_wayland():
+            self.set_mode_by_caps_lock(self._keymap.get_caps_lock_state())
+            self._keymap_handler = self._keymap.connect('state-changed', self._keymap_state_changed_cb)
         self._settings_handler = self._settings.connect('changed', self._config_value_changed_cb)
 
     def do_focus_in(self) -> None:
@@ -1545,7 +1549,8 @@ class EngineHiragana(EngineModeless):
         return True
 
     # Note IBus.ModifierType.LOCK_MASK bit is always off with the text boxes
-    # inside GNOME Shell on X11. This issue is fixed with Wayland.
+    # inside GNOME Shell on X11, so X11 needs Gdk.Keymap for CapsLock state
+    # while Wayland tracks it from Caps_Lock key events.
     def do_process_key_event(self, keyval: int, keycode: int, state: int) -> bool:
         LOGGER.debug(f'do_process_key_event({keyval:#04x}({IBus.keyval_name(keyval)}), '
                      f'{keycode}, {state:#010x}({prettify_state(state)}))')

--- a/engine/event.py
+++ b/engine/event.py
@@ -1,6 +1,6 @@
 # ibus-hiragana - Hiragana IME for IBus
 #
-# Copyright (c) 2017-2024 Esrille Inc.
+# Copyright (c) 2017-2026 Esrille Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,10 +15,14 @@
 # limitations under the License.
 
 import logging
+from typing import TYPE_CHECKING
 
 import gi
 gi.require_version('IBus', '1.0')
 from gi.repository import IBus
+
+if TYPE_CHECKING:
+    from engine import EngineHiragana
 
 LOGGER = logging.getLogger(__name__)
 
@@ -205,7 +209,7 @@ class KeyboardController:
     def reset(self):
         self._modifiers = 0
 
-    def process_key_event(self, engine: IBus.Engine, keyval, keycode, state) -> bool:
+    def process_key_event(self, engine: 'EngineHiragana', keyval, keycode, state) -> bool:
         LOGGER.debug(f'process_key_event: {self._modifiers:#07x}')
 
         # Ignore XFree86 anomaly
@@ -272,22 +276,13 @@ class KeyboardController:
             if (self._modifiers & ALT_R_BIT) and keyval != IBus.Alt_R:
                 self._modifiers |= NOT_DUAL_ALT_R_BIT
 
-            # Check CAPS LOCK for IME on/off
-            if self._OnOffByCaps:
-                if keyval == IBus.Caps_Lock:
-                    # Note CAPS LOCK LED is turned off after the key release event.
-                    if state & IBus.ModifierType.LOCK_MASK:
-                        engine.disable_ime()
-                    else:
-                        engine.enable_ime()
-                    return False
-                elif not engine.is_overridden() and engine.is_wayland():
-                    # Do not run the following block on X11 due to the reason
-                    # commented in EngineHiragana.do_process_key_event.
-                    if state & IBus.ModifierType.LOCK_MASK:
-                        engine.enable_ime()
-                    else:
-                        engine.disable_ime()
+            if self._OnOffByCaps and keyval == IBus.Caps_Lock:
+                if engine.is_wayland():
+                    # Caps_Lock key press reports the previous LOCK_MASK
+                    # state because the CAPS LOCK LED changes after the key
+                    # release event, so invert it to track the new LED state.
+                    engine.set_mode_by_caps_lock(not (state & IBus.ModifierType.LOCK_MASK))
+                return False
 
             if keyval in (IBus.Muhenkan, IBus.Hangul_Hanja):
                 # [無変換], [A]


### PR DESCRIPTION
CapsLockによるIMEのモードきりかえをつぎのようになおす:
- X11では、Gdk.KeymapのCapsLock状態をつかう。
- Waylandでは、Caps_Lockキー押下イベントをつかう。

Closes #207